### PR TITLE
Array mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ ExecuteSQL.run "select count(*) from users where age > 50"
 # or with different mode
 # default mode: :print
 
+# return array of HashWithIndifferentAccess objects
+# please remember that arrays can be manipulated with Enumerable methods, but this is *not* a chainable ARel relation
+ExecuteSQL.run "select * from users where age > 50", mode: :array
+
+# return array of User objects
+ExecuteSQL.run "select * from users where age > 50", mode: :array, klass: User
+
 # return single value
 ExecuteSQL.run "select count(*) from users where age > 50", mode: :single
 

--- a/lib/execute_sql.rb
+++ b/lib/execute_sql.rb
@@ -22,13 +22,22 @@ require "execute_sql/railtie"
 module ExecuteSql
   module ConsoleMethods
     
-    def execute_sql(sql, mode: :print)
+    def execute_sql(sql, mode: :print, klass: HashWithIndifferentAccess)
       sql_query = ExecuteSql::SqlQuery.new("#{sql}".strip).execute
       rows = sql_query.data.rows
       cols = sql_query.data.columns
       case mode.to_s
       when 'print'
         puts Terminal::Table.new(rows: rows, headings: cols)
+      when 'array'
+        result = rows.map do |row|
+          record = klass.new
+          cols.each_with_index.map do |col, index|
+            record[col] = row[index]
+          end
+          record
+        end
+        result
       when 'raw'
         rows
       when 'single'

--- a/test/execute_sql_test.rb
+++ b/test/execute_sql_test.rb
@@ -10,5 +10,7 @@ class ExecuteSql::Test < ActiveSupport::TestCase
     puts ExecuteSQL.run("SELECT * from users where age > 26", mode: :single)
     puts ExecuteSQL.run("SELECT * from users where age > 26", mode: :raw)
     puts ExecuteSQL.run("SELECT * from users where age > 26", mode: :none)
+    puts ExecuteSQL.run("SELECT * from users where age > 26", mode: :array)
+    puts ExecuteSQL.run("SELECT * from users where age > 26", mode: :array, klass: User)
   end
 end


### PR DESCRIPTION
Return an array of hashes, where every element hash represents a model record. Defaults to HashWithIndifferentAccess but modifies the function signature to accept an optional third parameter to override the HWIA with the appropriate model class.